### PR TITLE
Optimize image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax=docker/dockerfile:1
 
+# Build the web app.
 FROM node:16 as web-builder
 
 WORKDIR /app
@@ -8,14 +9,13 @@ RUN npm install --legacy-peer-deps
 RUN npm run build
 
 
+# Build the Go binary.
 # Alpine is chosen for its small footprint
 # compared to Ubuntu
-FROM golang:1.17-alpine
+FROM golang:1.17-alpine as builder
 
 # Set working directory
 WORKDIR /app
-
-COPY --from=web-builder /app/dist /app/web/dist
 
 # Download necessary Go modules
 COPY go.mod ./
@@ -29,7 +29,17 @@ COPY ./main.go /app/
 COPY ./internal /app/internal
 
 
-RUN go build -o main
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-extldflags '-static'" -o main
+
+# Build production image
+FROM gcr.io/distroless/static:nonroot
+
+# Set working directory
+WORKDIR /app
+
+COPY --from=builder /app/main /app/main
+
+COPY --from=web-builder /app/dist /app/web/dist
 
 EXPOSE 8081
 


### PR DESCRIPTION
@Jont828 
Can you please take a look and potential considering a new release (at least of the image).

This PR should optimize the image size significantly:
```
# Before
ghcr.io/jont828/cluster-api-visualizer                                           v1.0.0                                         2954ce670693   2 months ago     1.16GB
# After
ghcr.io/jont828/cluster-api-visualizer                                           latest                                         8a805339853b   4 minutes ago    73MB
```

Would be great if we can use the optimized image size for our tutorial at KubeCon