### PR TITLE
Restrict Access to resources other than cluster-api one

### DIFF
--- a/helm/cluster-api-visualizer/templates/clusterrole.yaml
+++ b/helm/cluster-api-visualizer/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   name: capi-visualizer
 rules:
-# TODO: Consider restricting the rights to the relevant CAPI apiGroups.
 - apiGroups:
   - ''
   resources:

--- a/helm/cluster-api-visualizer/templates/clusterrole.yaml
+++ b/helm/cluster-api-visualizer/templates/clusterrole.yaml
@@ -5,7 +5,29 @@ metadata:
 rules:
 # TODO: Consider restricting the rights to the relevant CAPI apiGroups.
 - apiGroups:
+  - ''
+  resources:
   - '*'
+  verbs:
+  - 'list'
+  - 'get'
+  - 'watch'
+- apiGroups:
+  - 'apiextensions.k8s.io'
+  resources:
+  - 'customresourcedefinitions'
+  verbs:
+  - 'list'
+  - 'get'
+  - 'watch'
+- apiGroups:
+  - 'cluster.x-k8s.io'
+  - 'addons.cluster.x-k8s.io'
+  - 'bootstrap.cluster.x-k8s.io'
+  - 'controlplane.cluster.x-k8s.io'
+  - 'ipam.cluster.x-k8s.io'
+  - 'infrastructure.cluster.x-k8s.io'
+  - 'runtime.cluster.x-k8s.io'
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
To prevent unintentional changes to cluster-api-controller or other resources

this could probably restricted much more than this

fixes: https://github.com/Jont828/cluster-api-visualizer/issues/13
