### PR TITLE
Add initial support for showing custom CRD types in the Cluster tree view

### DIFF
--- a/api/v1/common_types.go
+++ b/api/v1/common_types.go
@@ -1,0 +1,12 @@
+package api
+
+const (
+	// VisualizeResourceLabel is used to include additional CRDs outside of clusterctl discovery
+	// into the Cluster view. The label should be applied to the CRD type itself, and the resource
+	// instances must have the `cluster.x-k8s.io/cluster-name` in order to be affiliated with a
+	// Cluster.
+	// The resource will be inserted into the tree based off its owner reference, and its owners
+	// will be inserted as well until the owner is a Cluster, or it has no owner, in which case it
+	// will be added as a child of the Cluster.
+	VisualizeResourceLabel = "visualizer.cluster.x-k8s.io"
+)

--- a/docs/including-additional-crds.md
+++ b/docs/including-additional-crds.md
@@ -1,0 +1,15 @@
+# Including additional CRD types in the Cluster view
+
+The Cluster view lists all the CRDs returned by the discovery process in `clusterctl describe`. To add additional CRDs, you must modify the CRD type (not the instances) with the `visualizer.cluster.x-k8s.io: ""` label as follows:
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    visualizer.cluster.x-k8s.io: ""
+```
+
+The instances of the CRD must also have the `cluster.x-k8s.io/cluster-name: <cluster-name>` label in order to be affiliated with a Cluster. 
+
+The CRD instance will then be displayed in the Cluster view such that it will be listed as a child of its controller reference. If the controller reference is not in the tree, it will be added as well, and if there is no controller reference, it will be a child of the Cluster object at the root of the tree.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.2
+	k8s.io/apiextensions-apiserver v0.27.2
 	k8s.io/apimachinery v0.27.2
 	k8s.io/client-go v0.27.2
 	k8s.io/klog/v2 v2.90.1
@@ -93,7 +94,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.27.2 // indirect
 	k8s.io/apiserver v0.27.2 // indirect
 	k8s.io/cluster-bootstrap v0.27.2 // indirect
 	k8s.io/component-base v0.27.2 // indirect

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -1,0 +1,159 @@
+package internal
+
+import (
+	"context"
+	"strings"
+
+	visualizerv1 "github.com/Jont828/cluster-api-visualizer/api/v1"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// getCRDList is a helper function to list all CRDs with the visualize label for constructing the DescribeCluster resource tree.
+func getCRDList(ctx context.Context, c ctrlclient.Client) ([]apiextensionsv1.CustomResourceDefinition, error) {
+	crdList := &apiextensionsv1.CustomResourceDefinitionList{}
+	if err := c.List(ctx, crdList, ctrlclient.HasLabels{visualizerv1.VisualizeResourceLabel}); err != nil {
+		return nil, errors.Wrap(err, "failed to get the list of CRDs required for the move discovery phase")
+	}
+
+	return crdList.Items, nil
+}
+
+// getObjList is a helper function to list objects of a specific type for constructing the DescribeCluster resource tree.
+func getObjList(ctx context.Context, c ctrlclient.Client, typeMeta metav1.TypeMeta, selectors []ctrlclient.ListOption, objList *unstructured.UnstructuredList) error {
+	objList.SetAPIVersion(typeMeta.APIVersion)
+	objList.SetKind(typeMeta.Kind)
+
+	if err := c.List(ctx, objList, selectors...); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "failed to list %q resources", objList.GroupVersionKind())
+	}
+
+	return nil
+}
+
+// updateSeverityIfMoreSevere takes an existing severity and a new severity and returns the more severe of the two based on the rule that Error > Warning > Info > None.
+// This is used to determine the severity of a group node, i.e. a node representing 2 Machines in the DescribeCluster resource tree.
+func updateSeverityIfMoreSevere(existingSev string, newSev string) string {
+	switch {
+	case existingSev == "":
+		return newSev
+	case existingSev == "Info":
+		if newSev == "Error" || newSev == "Warning" {
+			return newSev
+		}
+		return existingSev
+	case existingSev == "Warning":
+		if newSev == "Error" {
+			return newSev
+		}
+		return existingSev
+	case existingSev == "Error":
+		return existingSev
+	}
+
+	return existingSev
+}
+
+// getProvider returns the provider type for an object in the Cluster resource tree. If the object is a virtual object and its kind is
+// listed in treeOptions.VNodesToInheritChildProvider, the provider type of the object's children is checked. If all children have the
+// same provider type, the provider type is inherited. If the object is not a virtual object, the provider type is looked up directly.
+func getProvider(object ctrlclient.Object, children []ctrlclient.Object, treeOptions ClusterResourceTreeOptions) (string, error) {
+	log := klogr.New()
+
+	if tree.IsVirtualObject(object) {
+		_, inherit := treeOptions.VNodesToInheritChildProvider[object.GetObjectKind().GroupVersionKind().Kind]
+		if !inherit {
+			return "virtual", nil
+		}
+		log.V(4).Info("Aggregating object w/ kind, name, and metaName", "kind", object.GetObjectKind().GroupVersionKind().Kind, "name", object.GetName(), "metaName", tree.GetMetaName(object))
+
+		prev := ""
+		for i, child := range children {
+			provider, err := lookUpProvider(child)
+			if err != nil {
+				return "", err
+			}
+			log.V(4).Info("Child object w/ kind, name, and provider", "kind", object.GetObjectKind().GroupVersionKind().Kind, "name", object.GetName(), "metaName", tree.GetMetaName(object))
+
+			if provider == "virtual" { // Do not inherit virtual provider
+				return "virtual", nil
+			}
+			if i > 0 && provider != prev { // If two children have different providers, don't inherit
+				return "virtual", nil
+			}
+			prev = provider
+		}
+
+		return prev, nil
+	} else {
+		return lookUpProvider(object)
+	}
+}
+
+// lookUpProvider returns the provider type of an object in the Cluster resource tree based off of the group in the GVK.
+// If the object is a virtual object, the provider type is "virtual".
+func lookUpProvider(object ctrlclient.Object) (string, error) {
+	group := object.GetObjectKind().GroupVersionKind().Group
+	if capiAPIVersionIndex := strings.Index(group, "cluster.x-k8s.io"); capiAPIVersionIndex < 0 {
+		return "virtual", nil
+	}
+
+	providerIndex := strings.IndexByte(group, '.')
+	if tree.IsVirtualObject(object) {
+		return "virtual", nil
+	} else if providerIndex > -1 {
+		return group[:providerIndex], nil
+	} else {
+		return "", errors.Errorf("No provider found for object %s of %s \n", object.GetName(), object.GetObjectKind().GroupVersionKind().String())
+	}
+}
+
+// getDisplayName returns the name of an object or the metaName if the object is virtual or has no name.
+func getDisplayName(object ctrlclient.Object) string {
+	metaName := tree.GetMetaName(object)
+	displayName := object.GetName()
+	if metaName != "" {
+		if object.GetName() == "" || tree.IsVirtualObject(object) {
+			displayName = metaName
+		}
+	}
+
+	return displayName
+}
+
+// setReadyFields sets a marker on if an object has a ready condtion, and if so, whether it is ready or not and the severity of the condition.
+func setReadyFields(object ctrlclient.Object, node *ClusterResourceNode) {
+	if readyCondition := tree.GetReadyCondition(object); readyCondition != nil {
+		node.HasReady = true
+		node.Ready = readyCondition.Status == corev1.ConditionTrue
+		node.Severity = string(readyCondition.Severity)
+	}
+}
+
+// nodeArrayNames is a debug function that returns the <Kind>/<Name> of all nodes in a slice of ClusterResourceNodes.
+func nodeArrayNames(nodes []*ClusterResourceNode) string {
+	result := ""
+	for _, node := range nodes {
+		result += node.Kind + "/" + node.Name + " "
+	}
+
+	return result
+}
+
+// getSortKeys returns the sort keys for a node in the DescribeCluster resource tree. The sort keys are used to sort the children of a node.
+func getSortKeys(node *ClusterResourceNode) []string {
+	if node.Group == "virtual.cluster.x-k8s.io" {
+		return []string{node.DisplayName, ""}
+	}
+	return []string{node.Kind, node.DisplayName}
+}

--- a/main.go
+++ b/main.go
@@ -136,6 +136,10 @@ func main() {
 		log.Error(httpErr, "failed to initialize client, will allow frontend to start") // Try to initialize client but allow GUI to start anyway even if it fails
 	}
 
+	// if _, err := internal.FetchLabeledCustomResources(c.ControllerRuntimeClient); err != nil {
+	// 	log.Error(err, "failed to fetch labeled custom resources")
+	// }
+
 	http.Handle("/api/v1/management-cluster/", http.HandlerFunc(handleManagementClusterTree))
 	http.Handle("/api/v1/custom-resource-definition/", http.HandlerFunc(handleCustomResourceDefinitionTree))
 	http.Handle("/api/v1/describe-cluster/", http.HandlerFunc(handleDescribeClusterTree))
@@ -290,7 +294,7 @@ func handleDescribeClusterTree(w http.ResponseWriter, r *http.Request) {
 		ShowTemplates:           true,
 	}
 
-	tree, httpErr := internal.ConstructClusterResourceTree(c.ClusterctlClient, dcOptions)
+	tree, httpErr := internal.ConstructClusterResourceTree(c.ClusterctlClient, c.ControllerRuntimeClient, dcOptions)
 	if httpErr != nil {
 		log.Error(httpErr, "failed to construct resource tree for target cluster", "clusterName", name)
 		http.Error(w, httpErr.Error(), httpErr.Status)


### PR DESCRIPTION
Allows users to add the `visualizer.cluster.x-k8s.io: ""` and `cluster.x-k8s.io/cluster-name: <cluster-name>` label to show additional CRD types in the Cluster tree view.