### PR TITLE
Add ClusterRole to list all resources

### DIFF
--- a/helm/cluster-api-visualizer/templates/clusterrole.yaml
+++ b/helm/cluster-api-visualizer/templates/clusterrole.yaml
@@ -31,6 +31,15 @@ rules:
   - '*'
   verbs:
   - '*'
+# Note: this is a fallback to allow the visualizer to work with user-specific CRDs.
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - 'list'
+  - 'get'
+  - 'watch'
 - nonResourceURLs:
   - '*'
   verbs:


### PR DESCRIPTION
This allows the visualizer to discover CRD types that the user specifies using labels.