### PR TITLE
Set CRD treeview to open all by default

### DIFF
--- a/web/src/components/CustomResourceDefinition.vue
+++ b/web/src/components/CustomResourceDefinition.vue
@@ -125,6 +125,7 @@
         :search="search"
         :filter="filter"
         :open.sync="open"
+        open-all="true"
         :active.sync="active"
         activatable
         rounded


### PR DESCRIPTION
The search function only works on open treeview nodes, so this allows the search to search through all the fields at the beginning.